### PR TITLE
Feature/aqm canopy new

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,2 @@
 Modified branch to account for in-canopy effects on composition/weather
-Adding New canopy data
+Export 5 2D canopy data fields and 3 2D photolysis diagnostics (I. Ivanova, 02/14/2024)

--- a/README
+++ b/README
@@ -1,1 +1,2 @@
 Modified branch to account for in-canopy effects on composition/weather
+Adding New canopy data

--- a/src/aqm_cap.F90
+++ b/src/aqm_cap.F90
@@ -64,7 +64,7 @@ module AQM
 !      "cum_lai_frac4_eccc                       ", &
     /)
   ! -- export fields
-  integer, parameter :: exportFieldCount = 2+3+5  !IVAI: add 3 photolysis inst_tracer_diag_*
+  integer, parameter :: exportFieldCount = 2+3+5  !IVAI: add 3 photolysis inst_tracer_diag_* and five canopy variables
   character(len=*), dimension(exportFieldCount), parameter :: &
     exportFieldNames = (/ &
       "inst_tracer_mass_frac                ", &

--- a/src/aqm_cap.F90
+++ b/src/aqm_cap.F90
@@ -9,7 +9,7 @@ module AQM
 
   use aqm_comp_mod
   use aqm_const_mod, only: rad_to_deg
-  
+
   implicit none
 
   ! -- import fields
@@ -55,7 +55,7 @@ module AQM
       "temperature_of_soil_layer                "  &
 !      "forest_canopy_height                     ", &
 !      "forest_fraction                          ", &
-!      "clumping_index                           ", &      
+!      "clumping_index                           ", &
 !      "population_density                       ", &
 !      "leaf_area_index_eccc                     ", &
 !      "cum_lai_frac1_eccc                       ", &
@@ -64,28 +64,36 @@ module AQM
 !      "cum_lai_frac4_eccc                       ", &
     /)
   ! -- export fields
-  integer, parameter :: exportFieldCount = 2
+  integer, parameter :: exportFieldCount = 2+3+5  !IVAI: add 3 photolysis inst_tracer_diag_*
   character(len=*), dimension(exportFieldCount), parameter :: &
     exportFieldNames = (/ &
       "inst_tracer_mass_frac                ", &
-      "inst_tracer_diag_aod                 "  &
+      "inst_tracer_diag_aod                 ", &
+      "inst_tracer_diag_claie               ", & !IVAI: canopy via aqm_emis_read
+      "inst_tracer_diag_cfch                ", & !IVAI: canopy via aqm_emis_read
+      "inst_tracer_diag_cfrt                ", & !IVAI: canopy via aqm_emis_read
+      "inst_tracer_diag_cclu                ", & !IVAI: canopy via aqm_emis_read
+      "inst_tracer_diag_cpopu               ", & !IVAI: canopy via aqm_emis_read
+      "inst_tracer_diag_coszens             ", & !IVAI: photdiag
+      "inst_tracer_diag_jo3o1d              ", & !IVAI: photdiag
+      "inst_tracer_diag_jno2                "  & !IVAI: photdiag
     /)
 
   private
 
   public SetServices
-  
+
   !-----------------------------------------------------------------------------
   contains
   !-----------------------------------------------------------------------------
-  
+
   subroutine SetServices(model, rc)
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
 
     ! begin
     rc = ESMF_SUCCESS
-    
+
     ! the NUOPC model component will register the generic methods
     call NUOPC_CompDerive(model, inheritModel, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -130,7 +138,7 @@ module AQM
       return  ! bail out
 
   end subroutine
-  
+
   !-----------------------------------------------------------------------------
 
   subroutine InitializeP0(model, importState, exportState, clock, rc)
@@ -138,7 +146,7 @@ module AQM
     type(ESMF_State)     :: importState, exportState
     type(ESMF_Clock)     :: clock
     integer, intent(out) :: rc
-    
+
     ! local variables
     integer                    :: verbosity
     character(len=ESMF_MAXSTR) :: msgString, name, rcFile
@@ -205,16 +213,16 @@ module AQM
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-    
+
   end subroutine
-  
+
   !-----------------------------------------------------------------------------
   subroutine InitializeP1(model, importState, exportState, clock, rc)
     type(ESMF_GridComp)  :: model
     type(ESMF_State)     :: importState, exportState
     type(ESMF_Clock)     :: clock
     integer, intent(out) :: rc
-    
+
     ! begin
     rc = ESMF_SUCCESS
 
@@ -295,7 +303,7 @@ module AQM
       return  ! bail out
 
     ! -- check if import fields are defined
-    if (importFieldCount < 1) then 
+    if (importFieldCount < 1) then
       call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
         msg="This component requires import fields to be defined.", &
         line=__LINE__, file=__FILE__, &
@@ -304,7 +312,7 @@ module AQM
     end if
 
     ! -- check if export fields are defined
-    if (exportFieldCount < 1) then 
+    if (exportFieldCount < 1) then
       call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
         msg="This component requires export fields to be defined.", &
         line=__LINE__, file=__FILE__, &
@@ -427,7 +435,7 @@ module AQM
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-         
+
         do item = 1, 2
           call ESMF_GridGetCoord(grid, coordDim=item, staggerloc=ESMF_STAGGERLOC_CENTER, &
             localDE=localDe, farrayPtr=coord, rc=rc)
@@ -544,7 +552,7 @@ module AQM
   subroutine ModelAdvance(model, rc)
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
-    
+
     ! local variables
     type(ESMF_Clock)              :: clock
     type(ESMF_State)              :: importState, exportState
@@ -558,7 +566,7 @@ module AQM
 
     ! begin
     rc = ESMF_SUCCESS
-    
+
     ! get component's information
     call NUOPC_CompGet(model, name=name, diagnostic=diagnostic, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &

--- a/src/aqm_comp_mod.F90
+++ b/src/aqm_comp_mod.F90
@@ -325,6 +325,57 @@ contains
               line=__LINE__, &
               file=__FILE__)) &
               return  ! bail
+!IVAI: canopy fields read in via 'aqm_emiss_read'
+          case ("inst_tracer_diag_claie")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % claie, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_cfch")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % cfch, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_cfrt")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % cfrt, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_cclu")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % cclu, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_cpopu")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % cpopu, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+!IVAI: photdiag CTM_RJ_1 fields
+          case ("inst_tracer_diag_coszens")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % coszens, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_jo3o1d")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % jo3o1d, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+          case ("inst_tracer_diag_jno2")
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateOut % jno2, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__, &
+              file=__FILE__)) &
+              return  ! bail
+!IVAI
           case default
             ! -- unused field
         end select
@@ -605,7 +656,7 @@ contains
               line=__LINE__, &
               file=__FILE__)) &
               return  ! bail
-!canopy variables 
+!canopy variables
 !          case ("forest_canopy_height")
 !            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=stateIn % stemp, rc=rc)
 !            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &

--- a/src/shr/aqm_config_mod.F90
+++ b/src/shr/aqm_config_mod.F90
@@ -34,7 +34,7 @@ module aqm_config_mod
     logical                   :: biosw_yn      = .false.
     logical                   :: ctm_aod       = .false.
     logical                   :: ctm_depvfile  = .false.
-    logical                   :: ctm_photdiag  = .true.  !IVAI
+    logical                   :: ctm_photdiag  = .false.  !IVAI
     logical                   :: ctm_pmdiag    = .false.
     logical                   :: ctm_wb_dust   = .false.
     logical                   :: mie_optics    = .false.

--- a/src/shr/aqm_config_mod.F90
+++ b/src/shr/aqm_config_mod.F90
@@ -34,7 +34,7 @@ module aqm_config_mod
     logical                   :: biosw_yn      = .false.
     logical                   :: ctm_aod       = .false.
     logical                   :: ctm_depvfile  = .false.
-    logical                   :: ctm_photodiag = .false.
+    logical                   :: ctm_photdiag  = .true.  !IVAI
     logical                   :: ctm_pmdiag    = .false.
     logical                   :: ctm_wb_dust   = .false.
     logical                   :: mie_optics    = .false.
@@ -183,6 +183,17 @@ contains
       rcToReturn=rc)) &
       return  ! bail out
 
+!IVAI
+    ! -- read diagnostic settings
+    call ESMF_ConfigGetAttribute(cf, config % ctm_photdiag, &
+      label="ctm_photdiag:", default=.false., rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+!IVAI
+
     call ESMF_ConfigGetAttribute(cf, config % ctm_pmdiag, &
       label="ctm_pmdiag:", default=.false., rc=localrc)
     if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -242,7 +253,6 @@ contains
 
     ! -- set other default values
     config % ctm_depvfile  = .false.
-    config % ctm_photodiag = .false.
 
   end subroutine aqm_config_read
 
@@ -555,6 +565,25 @@ contains
         rcToReturn=rc)) &
         return  ! bail out
     end if
+!IVAI
+    if (config % ctm_photdiag) then
+      call ESMF_LogWrite(trim(name) // ": config: read: ctm_photdiag: true", &
+        ESMF_LOGMSG_INFO, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+    else
+      call ESMF_LogWrite(trim(name) // ": config: read: ctm_photdiag: false", &
+        ESMF_LOGMSG_INFO, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+    end if
+!IVAI
     if (config % ctm_wb_dust) then
       call ESMF_LogWrite(trim(name) // ": config: read: ctm_wb_dust: true", &
         ESMF_LOGMSG_INFO, rc=localrc)

--- a/src/shr/aqm_methods.F90
+++ b/src/shr/aqm_methods.F90
@@ -88,7 +88,7 @@ LOGICAL FUNCTION DESC3( FNAME )
   CHARACTER(LEN=*), INTENT(IN) :: FNAME
 
   INCLUDE SUBST_FILES_ID
- 
+
   integer :: localrc
   integer :: is, ie, js, je
   integer :: EMLAYS
@@ -372,8 +372,8 @@ logical function envyn(name, description, defaultval, status)
       envyn = config % ctm_depvfile
     case ('CTM_PMDIAG')
       envyn = config % ctm_pmdiag
-    case ('CTM_PHOTODIAG')
-      envyn = config % ctm_photodiag
+    case ('CTM_PHOTDIAG')
+      envyn = config % ctm_photdiag
     case ('CTM_PT3DEMIS')
       envyn = aqm_emis_ispresent("gbbepx") .or. &
               aqm_emis_ispresent("point-source")
@@ -551,7 +551,6 @@ INTEGER FUNCTION PROMPTFFILE( PROMPT, RDONLY, FMTTED, DEFAULT, CALLER )
 
 END FUNCTION PROMPTFFILE
 
-
 subroutine nameval(name, eqname)
 
   use aqm_emis_mod,  only : aqm_internal_emis_type, aqm_emis_get
@@ -600,7 +599,7 @@ subroutine nameval(name, eqname)
     case default
       ! -- nothing to do
   end select
-  
+
 end subroutine nameval
 
 
@@ -635,6 +634,7 @@ logical function interpx( fname, vname, pname, &
   real(AQM_KIND_R8), dimension(:,:,:), pointer     :: p3d
   type(aqm_config_type),               pointer     :: config
   type(aqm_state_type),                pointer     :: stateIn
+  type(aqm_state_type),                pointer     :: stateOut   !IVAI
 
   ! -- constants
   include SUBST_FILES_ID
@@ -651,6 +651,7 @@ logical function interpx( fname, vname, pname, &
   nullify(p3d)
   nullify(config)
   nullify(stateIn)
+  nullify(stateOut)  !IVAI
   set_non_neg = .false.
 
   if (trim(fname) == trim(GRID_CRO_2D)) then
@@ -715,7 +716,7 @@ logical function interpx( fname, vname, pname, &
     call aqm_model_get(stateIn=stateIn, rc=localrc)
     if (aqm_rc_check(localrc, msg="Failure to retrieve model input state", &
       file=__FILE__, line=__LINE__)) return
-    
+
     call aqm_model_get(config=config, stateIn=stateIn, rc=localrc)
     if (aqm_rc_check(localrc, msg="Failure to retrieve model input state", &
       file=__FILE__, line=__LINE__)) return
@@ -834,6 +835,113 @@ logical function interpx( fname, vname, pname, &
       case default
     !   return
     end select
+
+!IVAI
+    print*, 'AQM_METHODS: FNAME= ', FNAME, VNAME   !IVAI : MET_CRO_2D
+
+    IF ( TRIM( VNAME ) .EQ. TRIM('LAIE') ) THEN
+
+      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: LAIE
+!      print*, 'AQM_METHODS: LAIE = ', buffer(1:lbuf)
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      k = 0
+      do r = row0, row1
+        do c = col0, col1
+           k = k + 1
+
+           stateOut % CLAIE (c,r) = buffer(k)
+        end do
+      end do
+
+
+    END IF
+    IF ( TRIM( VNAME ) .EQ. TRIM('FCH') ) THEN
+
+      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: FCH
+!      print*, 'AQM_METHODS: FCH = ', buffer(1:lbuf)
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      k = 0
+      do r = row0, row1
+        do c = col0, col1
+           k = k + 1
+
+           stateOut % CFCH (c,r) = buffer(k)
+        end do
+      end do
+
+    END IF
+    IF ( TRIM( VNAME ) .EQ. TRIM('FRT') ) THEN
+
+      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: FRT
+!      print*, 'AQM_METHODS: FRT = ', buffer(1:lbuf)
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      k = 0
+      do r = row0, row1
+        do c = col0, col1
+           k = k + 1
+
+           stateOut % CFRT(c,r) = buffer(k)
+        end do
+      end do
+
+    END IF
+    IF ( TRIM( VNAME ) .EQ. TRIM('CLU') ) THEN
+
+      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: CLU
+!      print*, 'AQM_METHODS: CLU = ', buffer(1:lbuf)
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      k = 0
+      do r = row0, row1
+        do c = col0, col1
+           k = k + 1
+
+           stateOut % CCLU(c,r) = buffer(k)
+        end do
+      end do
+
+    END IF
+    IF ( TRIM( VNAME ) .EQ. TRIM('POPU') ) THEN
+
+      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: POPU
+!      print*, 'AQM_METHODS: POPU= ', buffer(1:lbuf)
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      k = 0
+      do r = row0, row1
+        do c = col0, col1
+           k = k + 1
+
+           stateOut % CPOPU(c,r) = buffer(k)
+        end do
+      end do
+
+    END IF
+
+!IVAI
 
   else if (trim(fname) == trim(OCEAN_1)) then
 
@@ -1232,7 +1340,11 @@ LOGICAL FUNCTION WRITE3_REAL2D( FNAME, VNAME, JDATE, JTIME, BUFFER )
 
     WRITE3_REAL2D = .FALSE.
 
+!    print*, 'AQM_METHODS: FNAME, VNAME= ', FNAME, VNAME !IVAI: CTM_AOD_1 ALL
+
     IF ( TRIM( VNAME ) .EQ. TRIM( ALLVAR3 ) ) THEN
+
+!      print*, 'AQM_METHODS: VNAME= ', VNAME         !IVAI: ADO
 
       nullify(stateOut)
       call aqm_model_get(stateOut=stateOut, rc=localrc)
@@ -1241,11 +1353,77 @@ LOGICAL FUNCTION WRITE3_REAL2D( FNAME, VNAME, JDATE, JTIME, BUFFER )
 
       stateOut % aod = BUFFER
 
+!      print*, 'AQM_METHODS: AOD  pointer = ', aod   !IVAI
+!      print*, 'AQM_METHODS: AOD = ', stateOut % aod !IVAI
+
     END IF
 
     WRITE3_REAL2D = .TRUE.
 
   END IF
+
+!IVAI
+  WRITE3_REAL2D = .TRUE.
+
+  IF ( TRIM( FNAME ) .EQ. TRIM( CTM_RJ_1 ) ) THEN
+
+    WRITE3_REAL2D = .FALSE.
+
+    print*, 'AQM_METHODS: FNAME= ', FNAME, VNAME   !IVAI: JO3O1D JNO2 ... (list of 15 vars)
+
+    IF ( TRIM( VNAME ) .EQ. TRIM('COSZENS') ) THEN
+
+!      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: COSZENS
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      stateOut % coszens = BUFFER
+
+!      print*, 'AQM_METHODS: COSZENS pointer = ', coszens
+!      print*, 'AQM_METHODS: COSZENS = ',  BUFFER
+
+    END IF
+
+    IF ( TRIM( VNAME ) .EQ. TRIM('JO3O1D') ) THEN
+
+!      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: JO3O1D
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      stateOut % JO3O1D = BUFFER
+
+!      print*, 'AQM_METHODS: JO3O1D pointer = ', JO3O1D
+!      print*, 'AQM_METHODS: JO3O1D = ', BUFFER
+
+    END IF
+
+    IF ( TRIM( VNAME ) .EQ. TRIM('JNO2') ) THEN
+
+!      print*, 'AQM_METHODS: VNAME= ', VNAME             !IVAI: JNO2
+
+      nullify(stateOut)
+      call aqm_model_get(stateOut=stateOut, rc=localrc)
+      if (aqm_rc_check(localrc, msg="Failure to retrieve model output state", &
+        file=__FILE__, line=__LINE__)) return
+
+      stateOut % JNO2 = BUFFER
+
+!      print*, 'AQM_METHODS: JNO2 pointer = ', JNO2
+!      print*, 'AQM_METHODS: JNO2 = ', BUFFER
+
+    END IF
+
+    WRITE3_REAL2D = .TRUE.
+
+  END IF ! CTM_RJ_1
+
+!IVAI
 
 END FUNCTION WRITE3_REAL2D
 

--- a/src/shr/aqm_state_mod.F90
+++ b/src/shr/aqm_state_mod.F90
@@ -46,12 +46,14 @@ module aqm_state_mod
 
     real(AQM_KIND_R8), dimension(:,:,:,:), pointer :: tr       => null()
 
+!IVAI
     ! -- canopy variables
-!    real(AQM_KIND_R8), dimension(:,:),     pointer :: cfch     => null()
-!    real(AQM_KIND_R8), dimension(:,:),     pointer :: cfrt     => null()
-!    real(AQM_KIND_R8), dimension(:,:),     pointer :: cclu     => null()
-!    real(AQM_KIND_R8), dimension(:,:),     pointer :: cpopu    => null()
-!    real(AQM_KIND_R8), dimension(:,:),     pointer :: claie    => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: cfch     => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: cfrt     => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: cclu     => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: cpopu    => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: claie    => null()
+!IVAI
 !    real(AQM_KIND_R8), dimension(:,:),     pointer :: cc1r     => null()
 !    real(AQM_KIND_R8), dimension(:,:),     pointer :: cc2r     => null()
 !    real(AQM_KIND_R8), dimension(:,:),     pointer :: cc3r     => null()
@@ -59,6 +61,12 @@ module aqm_state_mod
 
     ! -- diagnostics
     real(AQM_KIND_R8), dimension(:,:),     pointer :: aod      => null()
+!IVAI: photolysis
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: coszens  => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: jo3o1d   => null()
+    real(AQM_KIND_R8), dimension(:,:),     pointer :: jno2     => null()
+!
+!IVAI
 
   end type aqm_state_type
 


### PR DESCRIPTION
<!--Instructions: All subsequent sections of text should be filled in as appropriate.-->
## PR Checklist
- [y] This PR has been tested on an RDHPCS machine and/or WCOSS2. Please select below:
  - [y] RDHPCS.
  - [n] WCOSS2.

- [y] This PR has been tested with the ufs-srweather-app workflow online-cmaq branch.

- [n] New or updated input data is required by this PR. <!-- If checked, please work with the code managers to update input data sets on all platforms.-->

- [y] Baselines are expected to change.

## Description
<!--Provide a detailed description of what this PR does.-->

Export 5 2D canopy data fields and 3 2D photolysis diagnostics from AQM to FV3Atm:
- claie, cfch, cfrt, cclu, and cpopu fields, which are read in via 'aqm_emis_read'
- coszens, jo3o1d, and jno2 photolysis rates, which output is activated with 'ctm_photdiag' flag.

## Issue(s) addressed
<!--Please link the issues to be closed with this PR.
(Remember, issues must always be created before starting work on a PR branch!)
EX: - fixes #<issue_number>-->

Consistent use of AQM canopy data in photolysis and diffusion. Previously land-surface model Noah look-up table was used in the diffusion.

## Dependencies
<!--If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).
Do PRs in upstream/other repositories need to be merged along with this one?
EX: - waiting on noaa-emc/fv3atm/pull/<pr_number>-->

feature/aqm_canopy