### PR TITLE
Fix a bug in point source emission 

### DIFF
--- a/src/drv/cmaq_mod.F90
+++ b/src/drv/cmaq_mod.F90
@@ -528,12 +528,18 @@ contains
                do IRULE = 1,N_RULE
                  CALL UPCASE( DESID_RULES_NML( IRULE )%EMVAR )
                  if (DESID_EMVAR_TABLE( n )%NAME .EQ. DESID_RULES_NML( IRULE)%EMVAR ) then
-                    CALL UPCASE( DESID_RULES_NML( IRULE )%PHASE )
+                   if (DESID_RULES_NML( IRULE )%BASIS .EQ. 'UNIT') then
+                     CALL UPCASE( DESID_RULES_NML( IRULE )%PHASE )
                        if (DESID_RULES_NML( IRULE )%PHASE .EQ. 'GAS') then
                           em % table(spc,2) = "MOL/S" 
                        else
                           em % table(spc,2) = pmem_units
                        endif
+                   else if (DESID_RULES_NML( IRULE )%BASIS .EQ. 'MASS') then
+                           em % table(spc,2) = pmem_units
+                   else !BASIS can be set 'MOLE', but not in the default namelist
+                           em % table(spc,2) = "MOL/S"
+                   end if 
                  endif
                end do
 
@@ -574,6 +580,11 @@ contains
                   file=__FILE__, line=__LINE__, rc=rc)) return
                 em % factors(n) = ucnv * em % factors(n)
                 umap(n) = 0
+                !Wei Li write to log
+                if (em % species(n) .eq. 'SO2' .and. trim(etype(item)) .eq. 'point-source') then
+                  write(*,*) 'Test unit:',em % units(n),em % table(umap(n),2),DESID_EMVAR_TABLE( spc )%MW,em % dens_flag(n),ucnv
+                end if
+                !write to log end
               end if
             end if
           end do

--- a/src/drv/cmaq_mod.F90
+++ b/src/drv/cmaq_mod.F90
@@ -580,11 +580,6 @@ contains
                   file=__FILE__, line=__LINE__, rc=rc)) return
                 em % factors(n) = ucnv * em % factors(n)
                 umap(n) = 0
-                !Wei Li write to log
-                if (em % species(n) .eq. 'SO2' .and. trim(etype(item)) .eq. 'point-source') then
-                  write(*,*) 'Test unit:',em % units(n),em % table(umap(n),2),DESID_EMVAR_TABLE( spc )%MW,em % dens_flag(n),ucnv
-                end if
-                !write to log end
               end if
             end if
           end do

--- a/src/model/src/PT3D_STKS_DEFN.F
+++ b/src/model/src/PT3D_STKS_DEFN.F
@@ -175,10 +175,11 @@ C             LOGDEV = SETUP_LOGDEV()
 C set number of emissions layers depending on whether plumerise is on
 
             CALL AQM_EMIS_DESC( ETYPE, NLAYS=EMLYRS )
-            PTLAYS = EMLYRS
-
+           
             FIRSTIME = .FALSE.
          END IF
+          
+         PTLAYS = EMLYRS
 
 C Allocate Buffer space for Reading Emissions
          NSRC = SIZE( EM % IJMAP )


### PR DESCRIPTION
<!--Instructions: All subsequent sections of text should be filled in as appropriate.-->
## PR Checklist
- [ ] This PR has been tested on an RDHPCS machine and/or WCOSS2. Please select below:
  - [! ] RDHPCS.
  - [ ] WCOSS2.

- [ !] This PR has been tested with the ufs-srweather-app workflow aqm-dev branch.

- [ ] New or updated input data is required by this PR. <!-- If checked, please work with the code managers to update input data sets on all platforms.-->

- [ ] Baselines are expected to change.

## Description
<!--Provide a detailed description of what this PR does.-->
There is a bug in the point source emissions, in which only the first layer emissions are read in. This leads to much lower SO2. It is solved through this PR. Other changes are related to the emission unit, which has no impact on the results.

## Issue(s) addressed
<!--Please link the issues to be closed with this PR.
(Remember, issues must always be created before starting work on a PR branch!)
EX: - fixes #<issue_number>-->

SO2 is too low after the updates to be coupled with CMAQ54.

## Dependencies
<!--If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).
Do PRs in upstream/other repositories need to be merged along with this one?
EX: - waiting on noaa-emc/fv3atm/pull/<pr_number>-->
